### PR TITLE
Correct README for weather checker- adjust relative paths for file copies

### DIFF
--- a/examples/bee-hive/weather-checker/README.md
+++ b/examples/bee-hive/weather-checker/README.md
@@ -6,11 +6,11 @@ A multi-agent workflow using Bee-Hive to check if the current temperature in a l
 
 * Run a local instance of the Bee Stack
 
-* Install dependencies: `pip install -r ../../bee-hive/requirements.txt`
+* Install dependencies: `pip install -r ../../../bee-hive/requirements.txt`
 
 * Configure environmental variables: `cp example.env .env`
 
-* Copy `.env` to main bee-hive directory: `cp .env ../../bee-hive`
+* Copy `.env` to main bee-hive directory: `cp .env ../../../bee-hive`
 
 * Create the agents: `./hive create agents.yaml`
 


### PR DESCRIPTION
The current weather checker app is under examples/bee-hive/weather-checker. My assumption is that the instructions placed here should work when the current working directory is this one.

As such the readme instructions for copying the .env file & installing dependencies are incorrect, as the top level directories being referring to are one level further up the tree.

