### PR TITLE
(DRAFT) feat(agents): Add support to workflow engine for third party agents

### DIFF
--- a/bee-hive/bee_hive/run_workflow.py
+++ b/bee-hive/bee_hive/run_workflow.py
@@ -71,6 +71,9 @@ class CrewAIAgentRunner(AgentRunner):
         # Implement CrewAI agent execution logic here
         # crew = Crew(agent_name, ...)
         # crew.kickoff() << this is how we kick it off in the sample code. Note could be additional tasks
+        
+        # TODO: We get called with prompt='New York' or similar. test agent needs { "location": "New York" }
+        #prompt2  = { "location": prompt }
         try: 
             # TODO: need to lookup method to call - base don agent name?
             self.instance.activity_crew().kickoff(prompt)

--- a/bee-hive/bee_hive/run_workflow.py
+++ b/bee-hive/bee_hive/run_workflow.py
@@ -274,10 +274,15 @@ def sequential_workflow(workflow):
 
     for agent in agents:
         try:
+
             agent_runner = AgentRunnerFactory.create_agent_runner(agent["name"])
-            # TODO: reinstate streaming support
-            #prompt=agent_runner.stream(prompt) if( workflow_yaml["spec"]["strategy"]["streaming"] and workflow_yaml["spec"]["strategy"]["output"] == "verbose" ) else agent_runner.run(prompt)
-            agent_runner.run(prompt)
+
+            if ( workflow_yaml["spec"]["strategy"]["output"]
+                 and 
+                 workflow_yaml["spec"]["strategy"]["output"] == "verbose" ):
+                prompt = agent_runner.stream(prompt)
+            else:
+                prompt = agent_runner.run(prompt)                
         except ValueError as e:
             print(e)
             raise(e)


### PR DESCRIPTION
**WORK IN PROGRESS**

This PR adds support for alternate agent runners
 - Crew.AI

 in addition to
 - Bee
 
 Caveats
  - Actual agents implemented in i-am-bee/bee-hive#121 (and will need some refactoring to work with this)
  - still need to load/access/place 3rd party agent code in `$PYTHONPATH` for execution
  - Uses agent name to determine technology. Can consider how to define tech in a later PR, perhaps a type in the yaml. But maybe we need more metadata or some packaging for agents. See i-am-bee/bee-hive#130
  - existing bee code not refactored. See i-am-bee/bee-hive#128
  - no test cases. See i-am-bee/bee-hive#127 for framework, i-am-bee/bee-hive-demos#5 for simple example
  - does not address work to define input/output schema 
  - does not split the class definitions to separate files - but if this approach looks ok it would be a logical step. See i-am-bee/bee-hive#128
  - does not implement a langgraph runner. See i-am-bee/bee-hive#129
  
 Design
  - Add abstract base class for an agent runner
  - Add classes based on above for each technology
  - Adds only init()/run()/stream
  - connect up existing bee implementation
  - implement a crewai runner

Testing
 - bee agent (weather) runs as before 
 - crewai agent runs from sample workflow (will be added in i-am-bee/bee-hive-demos#5)
 

 
