### PR TITLE
bee-hive in kubernetes

### DIFF
--- a/bee-hive/Dockerfile
+++ b/bee-hive/Dockerfile
@@ -40,15 +40,19 @@ ENV PYTHONUNBUFFERED=1
 # Install pip
 RUN python3.11 -m ensurepip --upgrade
 # Install dependencies and update then uninstall pip (not needed in final image)
-RUN python3.11 -m pip install openai pyyaml python-dotenv --no-cache-dir --upgrade && \
+RUN python3.11 -m pip install openai pyyaml python-dotenv flask --no-cache-dir --upgrade && \
     python3.11 -m pip uninstall -y pip
 
 COPY bee_hive ./bee_hive
 COPY entrypoint.sh .
 COPY run_workflow.py .
+COPY entrypoint_api.sh .
+COPY api.py .
 
 RUN chown -R 1000:100 /usr/src/app &&\
     mkdir /usr/src/app/media && chown 1000:100 /usr/src/app/media
 
+EXPOSE 5000
 USER 1000:100
-ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
+#ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
+ENTRYPOINT ["/usr/src/app/entrypoint_api.sh"]

--- a/bee-hive/README.md
+++ b/bee-hive/README.md
@@ -101,8 +101,9 @@ python run_workflow workflow.yaml
 
 * Build bee-hive container image: `./bee-hive.sh build` in	bee-hive/bee-hive directory
 
+* Deploy bee-hive: `./bee-hive.sh deploy BEE_API=http://xxx.xxx.xxx.xxx:4000 BEE_API_KEY=sk-proj-testkey`
+  * The required environment variables can be provided at the end of command argunets (e.g.  `BEE_API=http://192.168.86.45:4000`).
+
 * Prepare agent and workflow definition yaml files in the current directory (e.g. agent.yaml, workflow.yaml)
 
-* Run workflow: `./bee-hive.sh run $PWD agents.yaml workflow.yaml BEE_API=http://xxx.xxx.xxx.xxx:4000 BEE_API_KEY=sk-proj-testkey`
-  * The required environment variables can be provided at the end of command argunets (e.g.  `BEE_API=http://192.168.86.45:4000`).  
-  
+* Run workflow: `./bee-hive.sh run agents.yaml workflow.yaml

--- a/bee-hive/README.md
+++ b/bee-hive/README.md
@@ -95,13 +95,16 @@ python run_workflow workflow.yaml
 
 * Configure environmental variables: `cp example.env .env`
 
-### Run workflow in local environment with container runtime (e.g. podman)
+### Run workflow in local environment with container runtime (e.g. podman) or kubernetes cluster
 
 * Run a local instance of the [Bee Stack](https://github.com/i-am-bee/bee-stack)
+  * `curl` is required for `run` command
+  * for Kubernetes, `kubectl` and `sed` are required
 
-* Build bee-hive container image: `./bee-hive.sh build` in	bee-hive/bee-hive directory
+* Build bee-hive container image: `./bee-hive.sh build` in bee-hive/bee-hive directory
 
 * Deploy bee-hive: `./bee-hive.sh deploy BEE_API=http://xxx.xxx.xxx.xxx:4000 BEE_API_KEY=sk-proj-testkey`
+  * To deploy to kubernetes cluster, user `deploy-k` instead `deploy` as the first argument
   * The required environment variables can be provided at the end of command argunets (e.g.  `BEE_API=http://192.168.86.45:4000`).
 
 * Prepare agent and workflow definition yaml files in the current directory (e.g. agent.yaml, workflow.yaml)

--- a/bee-hive/README.md
+++ b/bee-hive/README.md
@@ -97,7 +97,8 @@ python run_workflow workflow.yaml
 
 ### Run workflow in local environment with container runtime (e.g. podman) or kubernetes cluster
 
-* Run a local instance of the [Bee Stack](https://github.com/i-am-bee/bee-stack)
+* Prepare required environments
+  * Run a local instance of the [Bee Stack](https://github.com/i-am-bee/bee-stack)
   * `curl` is required for `run` command
   * for Kubernetes, `kubectl` and `sed` are required
 
@@ -105,7 +106,7 @@ python run_workflow workflow.yaml
 
 * Deploy bee-hive: `./bee-hive.sh deploy BEE_API=http://xxx.xxx.xxx.xxx:4000 BEE_API_KEY=sk-proj-testkey`
   * To deploy to kubernetes cluster, user `deploy-k` instead `deploy` as the first argument
-  * The required environment variables can be provided at the end of command argunets (e.g.  `BEE_API=http://192.168.86.45:4000`).
+  * The required environment variables can be provided at the end of command arguments (e.g. `BEE_API=http://192.168.86.45:4000`).
 
 * Prepare agent and workflow definition yaml files in the current directory (e.g. agent.yaml, workflow.yaml)
 

--- a/bee-hive/README.md
+++ b/bee-hive/README.md
@@ -101,6 +101,10 @@ python run_workflow workflow.yaml
   * Run a local instance of the [Bee Stack](https://github.com/i-am-bee/bee-stack)
   * `curl` is required for `run` command
   * for Kubernetes, `kubectl` and `sed` are required
+  * set CONTAINER_CMD, TARGET_IP and BUILD_FLAGS environment variables to adjust bee-hive.sh script
+    * CONTAINER_CMD: docker, podman. nerdctl, etc..
+    * TARGET_IP: 127.0.0.1:"NodePort of the bee-hive service" for kubernetes deployment
+    * BUILD_FLAGS: image build command extra flag (e.g. "--namespace k8s.io" for nerdctl)
 
 * Build bee-hive container image: `./bee-hive.sh build` in bee-hive/bee-hive directory
 

--- a/bee-hive/README.md
+++ b/bee-hive/README.md
@@ -107,6 +107,7 @@ python run_workflow workflow.yaml
     * BUILD_FLAGS: image build command extra flag (e.g. "--namespace k8s.io" for nerdctl)
 
 * Build bee-hive container image: `./bee-hive.sh build` in bee-hive/bee-hive directory
+  * The built bee-hive:latest image need to be pushed/placed in the local retistry for kubernetes deployment
 
 * Deploy bee-hive: `./bee-hive.sh deploy BEE_API=http://xxx.xxx.xxx.xxx:4000 BEE_API_KEY=sk-proj-testkey`
   * To deploy to kubernetes cluster, user `deploy-k` instead `deploy` as the first argument

--- a/bee-hive/api.py
+++ b/bee-hive/api.py
@@ -1,0 +1,69 @@
+# Assisted by watsonx Code Assistant 
+from flask import Flask, request, jsonify
+import os
+import json
+import sys
+import io
+
+import yaml
+from bee_hive.workflow import Workflow
+
+app = Flask(__name__)
+
+def parse_yaml(file_path):
+    with open(file_path, "r") as file:
+        yaml_data = list(yaml.safe_load_all(file))
+    return yaml_data
+
+@app.route('/', methods=['POST'])
+def process_workflow():
+    if request.method == 'POST':
+        # Check if a file was uploaded
+        if 'agents' not in request.files:
+            return 'No agent definition'
+
+        agents = request.files['agents']
+
+        # Check if the file has a filename
+        if agents.filename == '':
+            return 'No agents file name'
+
+        # Save the file to the server
+        agents.save("agents")
+
+        if 'workflow' not in request.files:
+            return 'No agent definition'
+
+        workflow = request.files['workflow']
+
+        # Check if the file has a filename
+        if workflow.filename == '':
+            return 'No workflow file name'
+
+        # Save the file to the server
+        workflow.save("workflow")
+
+        agents_yaml = parse_yaml("agents")
+        workflow_yaml = parse_yaml("workflow")
+        try:
+            workflow_instance = Workflow(agents_yaml, workflow_yaml[0])
+        except Exception as excep:
+            raise RuntimeError("Unable to create agents") from excep
+
+        output = io.StringIO()
+        sys.stdout = output
+        workflow_instance.run()
+        sys.stdout = sys.__stdout__
+        
+        response = {
+            'workflow': workflow.filename,
+            'agents': agents.filename,
+            'output': output.getvalue()
+        }
+
+        return jsonify(response)
+
+    return render_template('upload.html')
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')
+

--- a/bee-hive/bee-hive.sh
+++ b/bee-hive/bee-hive.sh
@@ -1,24 +1,28 @@
 #!/bin/sh
 
 cmd=${CONTAINER_CMD:-docker}
-if [ "$1" != "build" ] && [ "$1" != "run" ]; then
-    echo "Invalid argument. Must be 'build' or 'run'."
+target=${TARGET_IP:-127.0.0.1:5000}
+if [ "$1" != "build" ] && [ "$1" != "deploy" ] && [ "$1" != "run" ]; then
+    echo "Invalid argument. Must be 'build', 'deploy' or 'run'."
     exit 1
 fi
 
 if [ "$1" == "build" ]; then
+    echo "Building..."
     $cmd build -t bee-hive .
-elif [ "$1" == "run" ]; then
-    echo "Running..."
-    path=$2
-    agents=$3
-    workflow=$4
+elif [ "$1" == "deploy" ]; then
+    echo "Deploying..."
     env=""
-    while [ "$5" != "" ]; do
-        env=$env" -e "$5" "
+    while [ "$2" != "" ]; do
+        env=$env" -e "$2" "
         shift
     done
-    $cmd run  $env --mount type=bind,src=$path,target=/data bee-hive /data/$agents /data/$workflow
+    $cmd run  -d $env -p $target:5000 bee-hive
+elif [ "$1" == "run" ]; then
+    echo "Running..."
+    agents=$2
+    workflow=$3
+    curl -X POST -L http://$target/ -F "agents=@$agents" -F "workflow=@$workflow"
 fi
 
 

--- a/bee-hive/bee-hive.yaml
+++ b/bee-hive/bee-hive.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bee-hive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bee-hive
+  template:
+    metadata:
+      labels:
+        app: bee-hive
+    spec:
+      containers:
+      - name: bee-hive
+        image: bee-hive:latest
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 5000
+        env:
+        - name: BEE_API_KEY
+          value: sk-proj-testkey
+        - name: BEE_API
+          value: http://192.168.86.45:4000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bee-hive
+spec:
+  selector:
+    app: bee-hive
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000
+  type: NodePort

--- a/bee-hive/bee-hive.yaml
+++ b/bee-hive/bee-hive.yaml
@@ -19,10 +19,8 @@ spec:
         ports:
         - containerPort: 5000
         env:
-        - name: BEE_API_KEY
-          value: sk-proj-testkey
-        - name: BEE_API
-          value: http://192.168.86.45:4000
+        - name: DUMMY
+          value: dummyvalue
 ---
 apiVersion: v1
 kind: Service

--- a/bee-hive/entrypoint_api.sh
+++ b/bee-hive/entrypoint_api.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+python3.11 api.py
+


### PR DESCRIPTION
This PR makes Bee-hive deployable and accessible in kubernetes.

A small API is added bee-hive image.  It accepts request with 2 yaml files and runs workflow.
This PR has kubernetes deployment and service (it's using a NodePort right now) yaml files.  The can be deployed with the kubectl.  The bee-hive with container runtime is also adjusted to use the API instead of mounting the local file system.  

The bee-hive.sh has 4 commands (the first argument)
* build: build container image
* deploy: deploy bee-hive in container service
* deploy-k: deploy bee-hive in kubernetes
* run: run the work flow in the environment

### Run workflow in local environment with container runtime (e.g. podman) or kubernetes cluster

* Prepare required environments
  * Run a local instance of the [Bee Stack](https://github.com/i-am-bee/bee-stack)
  * `curl` is required for `run` command
  * for Kubernetes, `kubectl` and `sed` are required

* Build bee-hive container image: `./bee-hive.sh build` in bee-hive/bee-hive directory

* Deploy bee-hive: `./bee-hive.sh deploy BEE_API=http://xxx.xxx.xxx.xxx:4000 BEE_API_KEY=sk-proj-testkey`
  * To deploy to kubernetes cluster, user `deploy-k` instead `deploy` as the first argument
  * The required environment variables can be provided at the end of command arguments (e.g. `BEE_API=http://192.168.86.45:4000`).

* Prepare agent and workflow definition yaml files in the current directory (e.g. agent.yaml, workflow.yaml)

* Run workflow: `./bee-hive.sh run agents.yaml workflow.yaml`
