### PR TITLE
fix(cli): Package cli for execution in dependent projects

### DIFF
--- a/bee-hive/bee_hive/__init__.py
+++ b/bee-hive/bee_hive/__init__.py
@@ -1,5 +1,6 @@
+
 __all__ = [
-    "agent",
-    "workflow",
-    "interface",
+    "Agent",
+    "Workflow",
+    "Interface",
 ]

--- a/bee-hive/cli/beeAI.py
+++ b/bee-hive/cli/beeAI.py
@@ -47,7 +47,7 @@ def run_cli():
     try:
         rc = command.execute()
         if rc != 0:
-            Console.error(f"executing command: {rc}".format(rc=rc))
+            Console.error("executing command: {rc}".format(rc=rc))
             sys.exit(rc)
     except Exception as e:
         Console.error(str(e))

--- a/bee-hive/cli/beeAI.py
+++ b/bee-hive/cli/beeAI.py
@@ -32,21 +32,26 @@ Options:
   -v --version                   Show version.
 
 """
-import os, sys, traceback
+import sys
 
 from docopt import docopt
+from cli.common import Console
+from cli.cli import CLI
 
-from cli import *
-
-if __name__ == '__main__':
+def run_cli():
+    """
+    run CLI command
+    """
     args = docopt(__doc__, version='beeAI CLI v0.0.1')
     command = CLI(args).command()
     try:
         rc = command.execute()
         if rc != 0:
-            Console.error("executing command: {rc}".format(rc=rc))
+            Console.error(f"executing command: {rc}".format(rc=rc))
             sys.exit(rc)
     except Exception as e:
         Console.error(str(e))
         sys.exit(1)
         
+if __name__ == '__main__':
+    run_cli()

--- a/bee-hive/cli/cli.py
+++ b/bee-hive/cli/cli.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io, sys
-
-from commands import *
-from common import *
+from cli.commands import Validate
 
 class CLI:
     def __init__(self, args):

--- a/bee-hive/cli/commands.py
+++ b/bee-hive/cli/commands.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io, sys, yaml, json, jsonschema
+import yaml, json, jsonschema
 
 from jsonschema.exceptions import ValidationError
-from common import Console
+from cli.common import Console
 
 # Base class for all commands
 class Command:

--- a/bee-hive/cli/common.py
+++ b/bee-hive/cli/common.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import sys
-from random import randint
 
 VERBOSE=False
 

--- a/bee-hive/pyproject.toml
+++ b/bee-hive/pyproject.toml
@@ -5,6 +5,10 @@ description = "A multi-agent platform with the vision to facilitate deploy and r
 authors = ["IBM"]
 license = "Apache 2.0"
 readme = "README.md"
+packages = [
+    { include = "bee_hive", from = "." },
+    { include = "cli", from = "." }
+]
 
 [tool.poetry.dependencies]
 python = ">= 3.11, < 3.13"
@@ -13,7 +17,6 @@ openai = "^1.56.2"
 python-dotenv = "^1.0.1"
 jsonschema = "^4.23.0"
 docopt-ng = "^0.9.0"
-
 
 [tool.poetry.group.dev.dependencies]
 
@@ -27,3 +30,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "-v -s"
+
+[tool.poetry.scripts]
+"beeAI" = "cli.beeAI:run_cli"


### PR DESCRIPTION
- Enables projects to specify a dependency on the bee project and run 'beeAI' directly

**Detail**:
 - Correct scope of some imports to work portably when picked up as a dependency (ie cli.XX)
 - added script definition to poetry config (poetry will automatically create shell script)
 - minor refactor to beeAI.py to move code to callable function (didn't work directly in main)
 

**Example**

In a new project which uses bee-hive, we can simply add bee-hive as a dependency:

```
[tool.poetry.dependencies]
python = ">= 3.11, < 3.13"
bee_hive = { git = "ssh://git@github.com/planetf1/bee-hive", subdirectory="bee-hive", branch="dev" }
```

Then in this new project, the following command works after a `poetry install`
```
(.venv) ➜  bee-hive git:(dev) beeAI validate file1 file2
validate file1 with schema file1
```

**Use Case**

- Building demos in bee-hive-demos where a project can just express dependency & all the right things happen

**Caveats**
- Example currently imports as git repo, and seems to pull in bee_hive & cli together - this may need to be separated - and seems to be causing an issue for dependent libraries currently. (
- not yet checked original script, removed original script, or verified other use cases
- current demo uses my fork/dev branch. When merged can use main repo/branch.
- if using a private repo, authentication is needed (works with ssh-agent)