### PR TITLE
fix(cli): import additional commands

### DIFF
--- a/bee-hive/cli/cli.py
+++ b/bee-hive/cli/cli.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cli.commands import Validate
+from cli.commands import Validate, Create, Run, Deploy
 
 class CLI:
     def __init__(self, args):


### PR DESCRIPTION
- Fixes an issue with 'create' command not working when running via a dependency

Now works ie:
```
(bee-hive-demos-py3.12) ➜  src git:(dev/jonesn/activitymerge) poetry update
Updating dependencies
Resolving dependencies... (39.6s)

Package operations: 0 installs, 1 update, 0 removals

  - Updating bee-hive (0.1.0 ebf3620 -> 0.1.0 637206f)

Writing lock file
(bee-hive-demos-py3.12) ➜  src git:(dev/jonesn/activitymerge) beeAI create agents.yaml                               
create: agents.yaml: OK.
```

Fixes #176 

