### PR TITLE
Separate agent creation from workflow creation

### DIFF
--- a/bee-hive/bee_hive/agent.py
+++ b/bee-hive/bee_hive/agent.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import abstractmethod
+import os
+import pickle
 
 class Agent:
     """
@@ -40,3 +42,40 @@ class Agent:
         Args:
             prompt (str): The prompt to run the agent with.
         """
+
+def _load_agent_db():
+    agents = {}
+    if os.path.exists('agents.db'):
+        with open('agents.db', 'rb') as f:
+            agents = pickle.load(f)
+    return agents
+
+def _save_agent_db(db):
+    with open('agents.db', 'wb') as f:
+        pickle.dump(db, f)
+
+def save_agent(agent):
+    """
+    Save agent in storage.
+    """
+    agents = _load_agent_db()
+    agent_data = pickle.dumps(agent)
+    agents[agent.agent_name] = agent_data
+    _save_agent_db(agents)
+
+def restore_agent(agent_name: str) -> Agent:
+    """
+    Restore agent from storage.
+    """
+    agents = _load_agent_db()
+    agent_data= agents[agent_name]
+    agent = pickle.loads(agent_data)
+    return(agent)
+
+def remove_agent(agent_name: str):
+    """
+    Remove agent from storage.
+    """
+    agents = _load_agent_db()
+    agents.pop(agent_name)
+    _save_agent_db(agents)


### PR DESCRIPTION
The agent can be create (by constructor) and saved (by save_agent method in agent.py)
The workflow constructor can take an array of agent definitions, an array of saved agent names or `None`(this case the agents listed in the workflow must be created and saved).

```python
import json
import os
import sys

import dotenv
import yaml
from bee_hive.workflow import Workflow
from bee_hive.bee_agent import BeeAgent
from bee_hive.agent import save_agent

dotenv.load_dotenv()

def parse_yaml(file_path):
    with open(file_path, "r") as file:
        yaml_data = list(yaml.safe_load_all(file))
    return yaml_data

if __name__ == "__main__":
    agents_yaml = parse_yaml("bee_hive/joke_agents_new.yaml")
    for agent_def in agents_yaml:
        agent = BeeAgent(agent_def)
        save_agent(agent)
    
    workflow_yaml = parse_yaml("bee_hive/joke_workflow_new.yaml")
    try:
        workflow = Workflow(None, workflow_yaml[0])
    except Exception as excep:
        raise RuntimeError("Unable to create agents") from except
    workflow.run()

```