### PR TITLE
unify organization structure of demos

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,10 +23,8 @@ jobs:
           poetry self add poetry-plugin-shell
       - name: Install dependencies
         run: |
-          cd bee-hive
           poetry install
 
       - name: Run unit tests
         run: |
-          cd bee-hive
           poetry run pytest

--- a/bee-hive-demos/agents/crewai/activity_planner/README.md
+++ b/bee-hive-demos/agents/crewai/activity_planner/README.md
@@ -2,24 +2,18 @@
 
 Simple agent which given a prompt including a city, will suggest things to do in the cold or wet weather
 
-Primarily this is to demonstrate how a Crew.AI Crew can be integrated into beehive.  Note that a crew can be composed of multiple agents
+Primarily this is to support a demonstration of how a Crew.AI Crew can be integrated into beehive.  Note that a crew can be composed of multiple agents
 
-## Usage
+# Requirements
 
-### Setup
+* Python 3.11/3.12
+* A valid project environment set-up by running the following from the root of the repository:
+  * `poetry shell`
+  * `poetry install`
 
-- `poetry shell`
-- `poetry install`
+# Running
 
-### Run
-
-- `./run.sh`
-
-### Test
-
-- `./test.sh`
-
-Note that this currently does the same as run
+* Run `bee-hive-demos/agents/crewai/activity_planner.py` via shell command line, or IDE such as vscode
 
 ## Future enhancements
 

--- a/bee-hive-demos/agents/crewai/activity_planner/activity_planner.py
+++ b/bee-hive-demos/agents/crewai/activity_planner/activity_planner.py
@@ -86,6 +86,7 @@ class ActivityPlannerCrew:
             process=Process.sequential,
             verbose=True,
         )
+        # TODO - returned content cannot be parsed by Workflow class.
 
 
 # Main for testing
@@ -93,3 +94,4 @@ if __name__ == "__main__":
     print("Running crew...")
     inputs = {"location": "San Francisco"}
     ActivityPlannerCrew().activity_crew().kickoff(inputs=inputs)
+    

--- a/bee-hive-demos/demos/activity-planner-crewai.ai/README.md
+++ b/bee-hive-demos/demos/activity-planner-crewai.ai/README.md
@@ -1,1 +1,21 @@
-demo
+# Introduction
+
+This is a simple demonstration of a workflow that uses a third party agent - in this case crew.ai
+
+# Requirements
+
+* Python 3.11/3.12
+* A valid project environment set-up by running the following from the root of the repository:
+  * `poetry shell`
+  * `poetry install`
+
+# Running
+
+* Run `bee-hive-demos/demos/activity-planner-crewai.ai/run.py` via shell command line, or IDE such as vscode
+
+# Caveats
+
+* Demo is incomplete and still being worked on including but not limited to
+  * Output from current agent cannot be parsed
+* `run.sh`, `doctor.sh`. `setup.sh` are currently not implemented
+* Demo is likely to be merged with `../activity-planner.ai`

--- a/bee-hive-demos/demos/activity-planner-crewai.ai/run.py
+++ b/bee-hive-demos/demos/activity-planner-crewai.ai/run.py
@@ -2,11 +2,12 @@
 
 import yaml
 import sys
+import os
 from bee_hive.workflow import Workflow
 
 
-# Add agent path to path explicitly - this should be found on path, but may require base change
-sys.path.append("agents/crewai/activity_planner")
+# TODO Add agent path to path explicitly - this should be found on path, but may require base change
+sys.path.append("bee-hive-demos/agents/crewai/activity_planner")
 
 def test_agent_runs() -> None:
     """
@@ -17,8 +18,8 @@ def test_agent_runs() -> None:
             yaml_data = list(yaml.safe_load_all(file))
         return yaml_data
 
-    agents_yaml = parse_yaml("demos/activity-planner-demo/agents.yaml")
-    workflow_yaml = parse_yaml("demos/activity-planner-demo/workflow.yaml")
+    agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"agents.yaml"))
+    workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"workflow.yaml"))
     try:
         workflow = Workflow(agents_yaml, workflow_yaml[0])
     except Exception as excep:

--- a/bee-hive-demos/demos/activity-planner-crewai.ai/workflow.yaml
+++ b/bee-hive-demos/demos/activity-planner-crewai.ai/workflow.yaml
@@ -14,7 +14,7 @@ spec:
         app: activity-planner-demo
     agents:
       - name: activity_planner.ActivityPlannerCrew.activity_crew
-  prompt: {"location": "San Francisco"}
-  steps:
-    - name: begin
-      agent: activity_planner.ActivityPlannerCrew.activity_crew
+    prompt: {"location": "San Francisco"}
+    steps:
+      - name: begin
+        agent: activity_planner.ActivityPlannerCrew.activity_crew

--- a/bee-hive/tests/bee/test_bee.py
+++ b/bee-hive/tests/bee/test_bee.py
@@ -3,7 +3,7 @@
 from unittest import TestCase
 import dotenv
 import yaml
-
+import os
 from pytest_mock import mocker
 
 from bee_hive.workflow import Workflow
@@ -31,8 +31,8 @@ def test_agent_runs(mocker) -> None:
     mock_bee=BeeAgentMock()
     mocker.patch.object(BeeAgent, "__new__", return_value = mock_bee)
         
-    agents_yaml = parse_yaml("tests/bee/agents.yaml")
-    workflow_yaml = parse_yaml("tests/bee/workflow.yaml")
+    agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"agents.yaml"))
+    workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"workflow.yaml"))
     try:
         workflow = Workflow(agents_yaml, workflow_yaml[0])
     except Exception as excep:

--- a/bee-hive/tests/crewai/test_crewai.py
+++ b/bee-hive/tests/crewai/test_crewai.py
@@ -3,32 +3,32 @@
 from unittest import TestCase
 import dotenv
 import yaml
-
+import os
 
 from bee_hive.workflow import Workflow
 
 dotenv.load_dotenv()
 
 # TODO: consider moving setup here
-#@pytest.fixture(scope="module")
+# @pytest.fixture(scope="module")
+
 
 class CrewAITest(TestCase):
-        
+
     def test_agent_runs(self) -> None:
         def parse_yaml(file_path):
             with open(file_path, "r", encoding="utf-8") as file:
                 yaml_data = list(yaml.safe_load_all(file))
             return yaml_data
 
-        agents_yaml = parse_yaml("tests/crewai/agents.yaml")
-        workflow_yaml = parse_yaml("tests/crewai/workflow.yaml")
+        agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"agents.yaml"))
+        workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"workflow.yaml"))
         try:
             workflow = Workflow(agents_yaml, workflow_yaml[0])
         except Exception as excep:
             raise RuntimeError("Unable to create agents") from excep
         result = workflow.run()
         print(result)
-        
-        assert result is not None
-        assert (result["final_prompt"]=="OK")
 
+        assert result is not None
+        assert result["final_prompt"] == "OK"

--- a/bee-hive/tests/workflow/test_sequence.py
+++ b/bee-hive/tests/workflow/test_sequence.py
@@ -4,6 +4,7 @@ import yaml
 import dotenv
 from unittest import TestCase
 from pytest_mock import mocker
+import os
 
 from bee_hive.workflow import Workflow
 from bee_hive.bee_agent import BeeAgent
@@ -28,7 +29,7 @@ def test_sequence_method(mocker):
     mock_agent2 = MockAgent("agent2")
     mock_agents = {"agent1": mock_agent1, "agent2": mock_agent2}
     mocker.patch.object(BeeAgent, "__new__", side_effect=lambda name: mock_agents[name])
-    workflow_yaml = parse_yaml("tests/workflow/workflow.yaml")
+    workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"workflow.yaml"))
     workflow_yaml[0]["spec"]["template"]["agents"] = []
     try:
         workflow = Workflow(agent_defs=[], workflow=workflow_yaml[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [
     { include = "bee_hive", from = "bee-hive" },
     { include = "cli", from = "bee-hive" },
-    # TODO - do demos need packaging? Only if you want to run after pip instal.. If so scripts need adding/renaming
+    # TODO - Packaging demos allows them to be run after a pip install 
     #{ include = "activity_planner", from = "bee-hive-demos/agents/crewai" }
 ]
 
@@ -37,7 +37,9 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-addopts = "-v -s"
+addopts = "-v -s --ignore=framework"
+#rootpath = "bee-hive"
 
 [tool.poetry.scripts]
 "beeAI" = "cli.beeAI:run_cli"
+# TODO Add scripts to run demos here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,31 @@ authors = ["IBM"]
 license = "Apache 2.0"
 readme = "README.md"
 packages = [
-    { include = "bee_hive", from = "." },
-    { include = "cli", from = "." }
+    { include = "bee_hive", from = "bee-hive" },
+    { include = "cli", from = "bee-hive" },
+    # TODO - do demos need packaging? Only if you want to run after pip instal.. If so scripts need adding/renaming
+    #{ include = "activity_planner", from = "bee-hive-demos/agents/crewai" }
 ]
 
 [tool.poetry.dependencies]
 python = ">= 3.11, < 3.13"
+openai = "^1.61.1"
 pyyaml = "^6.0.2"
-openai = "^1.56.2"
 python-dotenv = "^1.0.1"
 jsonschema = "^4.23.0"
 docopt-ng = "^0.9.0"
+# TODO Required by demos -- can split up, but then extra steps to install. See https://github.com/i-am-bee/bee-hive/issues/188
+langchain-community = "^0.3.16"
+duckduckgo-search = "^7.3.0"
+crewai = "^0.100.1"
+crewai-tools = "^0.33.0"
 
 [tool.poetry.group.dev.dependencies]
+black = "^24.10.0"
 
 [tool.poetry.group.test.dependencies]
-pytest-mock = "^3.14.0"
 pytest = "^8.3.4"
+pytest-mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/test/examples/test_condition.py
+++ b/test/examples/test_condition.py
@@ -8,7 +8,7 @@ import sys
 import dotenv
 from openai import OpenAI
 import yaml
-from workflow import Workflow
+from bee_hive.workflow import Workflow
 
 dotenv.load_dotenv()
 
@@ -21,8 +21,8 @@ def parse_yaml(file_path):
 
 
 if __name__ == "__main__":
-    agents_yaml = parse_yaml("condition_agents.yaml")
-    workflow_yaml = parse_yaml("condition_workflow.yaml")
+    agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"condition_agents.yaml"))
+    workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"condition_workflow.yaml"))
     try:
         workflow = Workflow(agents_yaml, workflow_yaml[0])
     except Exception as excep:


### PR DESCRIPTION
- [x] ** MERGE #185 #187 first ** (ideally merge not squash)

This update consolidates dependencies to a SINGLE pyproject.toml at the TOP LEVEL
This is a short-term fix to address needs for iteration 1


**Details**
 - merges changes from bee-hive-demos's pyproject.toml into single pyproject.toml
 - moves to top level (relative paths not permitted in project section, and demos now moved to `bee-hive-demos`)
 - module locations updated accordingly
 - fixed tests to run from top level. Since they are sometimes run locally, this was done by changing `a/b/c/agents.yaml` to `os.path.join(os.path.dirname(__file__),"agents.yaml")` which should be portable, as it looks for the file in the same directory as the test code.
 - fixed crewAI agent (standalone)
 - fixed (temporary) crewAI demo workflow
 - added simple READMEs for crewAI agent & example app
 - corrected import
 - updated CI to use new location
 - based on cherrypick of 605f3af790db0712d590e9562fdaab017df90580 , 49a24c32b161a38997b1e87d6d8d9de85c16ea83 , 00cff2ad8198ce88d8bb67246aa64cf9d35e87fa

**Testing**

* From CLI:
  - start in top level repo directory
  - `poetry shell` will create a virtual environment (if needed)
  - `poetry install` will setup all dependencies (and create package scripts)
  - Alternatively `poetry update` will resync all dependencies
  - `poetry run pytest` will run all tests
 
 * Tested run and debug within vscode (open file, click triangle to run etc)
 * Tested CI passes
 * Tested beeAI works when installed via `pip install git+ssh://git@github.com/planetf1/bee-hive.git@migratedemofix` (proves packaging/module resolution)
 * Tested crewAI agent works (via 'main' function) - automated test in future iteration as it needs crew specific stubs, and FV with working ollama (Run from IDE:`bee-hive-demos/agents/crewai/activity_planner/activity_planner.py`)
 * Tested crewAI app works. Temporary pending merge with main activity planner app. Run `bee-hive-demos/activity-planner-crewai.ai/run.py`

 **Note:**
  - I run test scripts usually from poetry, at the top level - or from the IDE. Both of these work. Reviewers - please check any use cases you have. I think file lookup is sorted, but module lookup may differ
  - We haven't yet moved bee-hive to the top level. However the demos are now. To get the definitions working, the simplest change was a single definition file, which needed to be higher up in the tree that bee-hive-demos, therefore it is added at the top. That goes against our preference to wait until other code removed, but it seemed the most pragmatic/workable option for now, without getting into complexity of multiple dependency chains.
  - Tests were left where they were - we can consider consolidation in a future iteration.
  - The temporary crewAI app is not using the src/test directories - as this causes more issues with file/module loading. Will address later - for example when merging with the other activity planning content
  - The agent needs more work, for example Workflow needs to use a get to retrieve output, but this isn't implemented
  - The intent is to merge the activity planner into the main demo, the above are precursor steps to achieve this & get the code to a working, stable base, equivalent to prior to the repo migration
  
**Further work**
- See #188 for background & ongoing discussion


