### PR TITLE
chore(internal): refactor imports

### DIFF
--- a/bee-hive-demos/demos/activity-planner-crewai.ai/run.py
+++ b/bee-hive-demos/demos/activity-planner-crewai.ai/run.py
@@ -3,7 +3,7 @@
 import yaml
 import sys
 import os
-from bee_hive.workflow import Workflow
+from bee_hive import Workflow
 
 
 # TODO Add agent path to path explicitly - this should be found on path, but may require base change

--- a/bee-hive-demos/demos/activity-planner.ai/src/run.py
+++ b/bee-hive-demos/demos/activity-planner.ai/src/run.py
@@ -2,7 +2,7 @@
 
 import sys
 import yaml
-from bee_hive.workflow import Workflow
+from bee_hive import Workflow
 import dotenv
 
 dotenv.load_dotenv()

--- a/bee-hive/bee_hive/__init__.py
+++ b/bee-hive/bee_hive/__init__.py
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 from .workflow import Workflow
 from .bee_agent import BeeAgent
+from .agent import save_agent, restore_agent, remove_agent

--- a/bee-hive/bee_hive/__init__.py
+++ b/bee-hive/bee_hive/__init__.py
@@ -1,6 +1,3 @@
-
-__all__ = [
-    "Agent",
-    "Workflow",
-    "Interface",
-]
+# SPDX-License-Identifier: Apache-2.0
+from .workflow import Workflow
+from .bee_agent import BeeAgent

--- a/bee-hive/bee_hive/agent_factory.py
+++ b/bee-hive/bee_hive/agent_factory.py
@@ -1,8 +1,8 @@
-
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 from typing import Callable, Type, Union
-from bee_hive.bee_agent import BeeAgent
-from bee_hive.crewai_agent import CrewAIAgent
+from .bee_agent import BeeAgent
+from .crewai_agent import CrewAIAgent
 
 class AgentFramework(Enum):
     """Enumeration of supported frameworks"""

--- a/bee-hive/bee_hive/bee_agent.py
+++ b/bee-hive/bee_hive/bee_agent.py
@@ -8,7 +8,7 @@ from openai import AssistantEventHandler, OpenAI
 from openai.types.beta import AssistantStreamEvent
 from openai.types.beta.threads.runs import RunStep, RunStepDelta, ToolCall
 
-from bee_hive.agent import Agent
+from .agent import Agent
 
 dotenv.load_dotenv()
 

--- a/bee-hive/bee_hive/crewai_agent.py
+++ b/bee-hive/bee_hive/crewai_agent.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
 
 import importlib
 
-from bee_hive.agent import Agent
+from .agent import Agent
 
 class CrewAIAgent(Agent):
     """

--- a/bee-hive/bee_hive/mock_agent.py
+++ b/bee-hive/bee_hive/mock_agent.py
@@ -8,7 +8,7 @@ from openai import AssistantEventHandler, OpenAI
 from openai.types.beta import AssistantStreamEvent
 from openai.types.beta.threads.runs import RunStep, RunStepDelta, ToolCall
 
-from bee_hive.agent import Agent
+from .agent import Agent
 
 dotenv.load_dotenv()
 

--- a/bee-hive/bee_hive/step.py
+++ b/bee-hive/bee_hive/step.py
@@ -1,16 +1,9 @@
 #! /usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-import os
-import sys
-
 import dotenv
-from openai import OpenAI
-import yaml
 
 dotenv.load_dotenv()
-from bee_hive.agent import Agent
 
 def eval_expression(expression, prompt):
     local = {}

--- a/bee-hive/bee_hive/workflow.py
+++ b/bee-hive/bee_hive/workflow.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from bee_hive.step import Step
-from bee_hive.agent_factory import AgentFramework
 import dotenv
+from .step import Step
+from .agent_factory import AgentFramework
 
 # TODO: Refactor later to factory or similar
-from bee_hive.crewai_agent import CrewAIAgent
-from bee_hive.bee_agent import BeeAgent
-from bee_hive.mock_agent import MockAgent
-from bee_hive.agent import restore_agent
+from .crewai_agent import CrewAIAgent
+from .bee_agent import BeeAgent
+from .mock_agent import MockAgent
+from .agent import restore_agent
 
 dotenv.load_dotenv()
 

--- a/bee-hive/cli/beeAI.py
+++ b/bee-hive/cli/beeAI.py
@@ -35,8 +35,8 @@ Options:
 import sys
 
 from docopt import docopt
-from cli.common import Console
-from cli.cli import CLI
+from .common import Console
+from .cli import CLI
 
 def run_cli():
     """

--- a/bee-hive/cli/cli.py
+++ b/bee-hive/cli/cli.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cli.commands import Validate, Create, Run, Deploy
+from .commands import Validate, Create, Run, Deploy
 
 class CLI:
     def __init__(self, args):

--- a/bee-hive/cli/commands.py
+++ b/bee-hive/cli/commands.py
@@ -15,7 +15,7 @@
 import yaml, json, jsonschema
 
 from jsonschema.exceptions import ValidationError
-from cli.common import Console
+from .common import Console
 
 # Base class for all commands
 class Command:

--- a/bee-hive/run_workflow.py
+++ b/bee-hive/run_workflow.py
@@ -9,7 +9,7 @@ import sys
 from openai import OpenAI
 import yaml
 import dotenv
-from bee_hive.workflow import Workflow
+from bee_hive import Workflow
 
 dotenv.load_dotenv()
 

--- a/bee-hive/tests/__init__.py
+++ b/bee-hive/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/bee-hive/tests/bee/__init__.py
+++ b/bee-hive/tests/bee/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/bee-hive/tests/bee/test_bee.py
+++ b/bee-hive/tests/bee/test_bee.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase
 import dotenv

--- a/bee-hive/tests/bee/test_bee.py
+++ b/bee-hive/tests/bee/test_bee.py
@@ -6,8 +6,9 @@ import yaml
 import os
 from pytest_mock import mocker
 
-from bee_hive.workflow import Workflow
-from bee_hive.bee_agent import BeeAgent
+# TODO consider moving to same directory as BeeAgent source
+from bee_hive import Workflow
+from bee_hive import BeeAgent
 
 dotenv.load_dotenv()
 

--- a/bee-hive/tests/crewai/__init__.py
+++ b/bee-hive/tests/crewai/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/bee-hive/tests/crewai/crew_dummy.py
+++ b/bee-hive/tests/crewai/crew_dummy.py
@@ -1,4 +1,5 @@
 # Dummy class for testing crewai loader
+# SPDX-License-Identifier: Apache-2.0
 
 class Crew:
     # TODO: kickoff actually takes & returns a dict[str,str]

--- a/bee-hive/tests/crewai/test_crewai.py
+++ b/bee-hive/tests/crewai/test_crewai.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase
 import dotenv

--- a/bee-hive/tests/crewai/test_crewai.py
+++ b/bee-hive/tests/crewai/test_crewai.py
@@ -2,10 +2,10 @@
 
 from unittest import TestCase
 import dotenv
-import yaml
 import os
+import yaml
 
-from bee_hive.workflow import Workflow
+from bee_hive import Workflow
 
 dotenv.load_dotenv()
 

--- a/bee-hive/tests/workflow/__init__.py
+++ b/bee-hive/tests/workflow/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/bee-hive/tests/workflow/pic.md
+++ b/bee-hive/tests/workflow/pic.md
@@ -1,0 +1,8 @@
+```mermaid
+  flowchart LR;
+      In-->LLM_Call_1;
+      LLM_Call_1-->|Output_1|Gate;
+      Gate-->|Pass|LLM_Call_2;
+      Gate-->|Fail|Exit;
+      LLM_Call_2 -->|Output_2|LLM_Call_3;
+      LLM_Call_3 --> Out;

--- a/bee-hive/tests/workflow/test_sequence.py
+++ b/bee-hive/tests/workflow/test_sequence.py
@@ -6,8 +6,8 @@ from unittest import TestCase
 from pytest_mock import mocker
 import os
 
-from bee_hive.workflow import Workflow
-from bee_hive.bee_agent import BeeAgent
+from bee_hive import Workflow
+from bee_hive import BeeAgent
 
 dotenv.load_dotenv()
 

--- a/bee-hive/tests/workflow/test_sequence.py
+++ b/bee-hive/tests/workflow/test_sequence.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
 import yaml
 import dotenv

--- a/test/examples/test_condition.py
+++ b/test/examples/test_condition.py
@@ -8,7 +8,7 @@ import sys
 import dotenv
 from openai import OpenAI
 import yaml
-from bee_hive.workflow import Workflow
+from bee_hive import Workflow
 
 dotenv.load_dotenv()
 


### PR DESCRIPTION
* Updates imports to:
  * Use . style within a module (ie within bee_hive)
  * Use 'from bee_hive import XX' elsewhere (in tests, demos)
 * Adds SPDX headers in .py files where not present 

Where necessary symbol exports were added in __init.py__

Tested:
* pytest, crewai agent, crewai workflow
* pip install & checked CLI runs
 
Caveat
* Only exported symbols *needed* by the above. This may be less than we expect consumers to need to actually use workflow. Or it may be more once the CLI is in place....

